### PR TITLE
Support for historical usernames with trailing hyphens.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ According to the form validation messages on [*Join Github*](https://github.com/
 * Github username may only contain alphanumeric characters or hyphens.
 * Github username cannot have multiple consecutive hyphens.
 * Github username cannot begin with a hyphen.
-** Github previously allowed usernames to end with a hyphen, but does not anymore.
+  * Github previously allowed usernames to end with a hyphen, but does not anymore.
 * Maximum is 39 characters.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -11,14 +11,15 @@ import githubUsernameRegex from 'github-username-regex';
 
 githubUsernameRegex.test('john'); //=> true
 githubUsernameRegex.test('john-due'); //=> true
-githubUsernameRegex.test('john-due-'); //=> false
+githubUsernameRegex.test('john--due'); //=> false
 ```
 
 According to the form validation messages on [*Join Github*](https://github.com/join) page,
 
 * Github username may only contain alphanumeric characters or hyphens.
 * Github username cannot have multiple consecutive hyphens.
-* Github username cannot begin or end with a hyphen.
+* Github username cannot begin with a hyphen.
+** Github previously allowed usernames to end with a hyphen, but does not anymore.
 * Maximum is 39 characters.
 
 ## Installation
@@ -50,6 +51,7 @@ Type: [`RegExp`](https://developer.mozilla.org/docs/Web/JavaScript/Guide/Regular
 githubUsernameRegex.test('a');
 githubUsernameRegex.test('0');
 githubUsernameRegex.test('a-b');
+githubUsernameRegex.test('a-b-');
 githubUsernameRegex.test('a-b-123');
 githubUsernameRegex.test('a'.repeat(39));
 
@@ -57,7 +59,7 @@ githubUsernameRegex.test('a'.repeat(39));
 githubUsernameRegex.test('');
 githubUsernameRegex.test('a_b');
 githubUsernameRegex.test('a--b');
-githubUsernameRegex.test('a-b-');
+githubUsernameRegex.test('a-b--');
 githubUsernameRegex.test('-a-b');
 githubUsernameRegex.test('a'.repeat(40));
 ```

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-var module$1 = /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i;
+var module$1 = /^[a-z\d](?:[a-z\d]|-(?!-)){0,38}$/i;
 
 module.exports = module$1;

--- a/module.js
+++ b/module.js
@@ -1,1 +1,1 @@
-export default /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i;
+export default /^[a-z\d](?:[a-z\d]|-(?!-)){0,38}$/i;

--- a/test.js
+++ b/test.js
@@ -5,22 +5,26 @@ const {strictEqual} = require('assert');
 
 for (const validName of [
   'a',
+  'A',
   'abc',
   'DEF',
   'Ghi',
   'a-z',
   'a-b-c',
+  'a-',
   '0',
   '10',
   '1-2',
+  '1-22-333-4444',
   'abc123',
   'abc-123',
-  'x'.repeat(39)
+  'x'.repeat(39),
+  'a'.concat('b-'.repeat(19))
 ]) {
   strictEqual(
     githubUsernameRegex.test(validName),
     true,
-    `Expected "${validName}" to be considiered as a valid Github username, but it wasn't.`
+    `Expected "${validName}" to be considered as a valid Github username, but it wasn't.`
   );
 }
 
@@ -31,8 +35,8 @@ for (const invalidName of [
   'a ',
   ' b',
   '-',
-  'a-',
   '-b',
+  'a--',
   'a--b',
   'a_b',
   'a\nb',
@@ -41,12 +45,13 @@ for (const invalidName of [
   'あ',
   '🍣',
   String.fromCharCode(15),
-  'x'.repeat(40)
+  'x'.repeat(40),
+  'aa'.concat('b-'.repeat(19))
 ]) {
   strictEqual(
     githubUsernameRegex.test(invalidName),
     false,
-    `Expected ${JSON.stringify(invalidName)} to be considiered as an invalid Github username, but it wasn't.`
+    `Expected ${JSON.stringify(invalidName)} to be considered as an invalid Github username, but it wasn't.`
   );
 }
 


### PR DESCRIPTION
By switching to a negated look-ahead assertion, the new `RegExp` can easily detect double hyphens while also allowing a single hyphen at the end of a username. We don't lose the following character checked against `[a-z\d]` from the positive look-ahead assertion as this is covered by the earlier instance of this in the expression.

Added new unit test cases and updated README.md.

Resolves #4.